### PR TITLE
change_user_passwordの実装、headerリンク先の修正

### DIFF
--- a/app/controllers/users/accounts_controller.rb
+++ b/app/controllers/users/accounts_controller.rb
@@ -18,6 +18,10 @@ class Users::AccountsController < ApplicationController
     end
   end
 
+  def show
+    @account = current_user
+  end
+
   def edit
     if !current_user
       redirect_to users_login_path

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,27 @@
+class Users::PasswordsController < ApplicationController
+  def show
+    redirect_to edit_users_password_path
+  end
+
+  def edit
+    @change_password_form =
+      Users::ChangePasswordForm.new(object: current_user)
+  end
+
+  def update
+    @change_password_form = Users::ChangePasswordForm.new(user_params)
+    @change_password_form.object = current_user
+    if @change_password_form.save
+      redirect_to users_account_path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+    def user_params
+      params.require(:users_change_password_form).permit(:current_password, :new_password, :new_password_confirmation)
+    end
+
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,16 +4,16 @@ class Users::SessionsController < ApplicationController
     if current_user
       redirect_to root_path
     else
-      @user = User.new
+      @user = Users::LoginForm.new
     end
   end
 
   def create
-    @user = User.create(user_params)
+    @user = Users::LoginForm.new(user_params)
     if @user.email.present?
       user = User.find_by(email: @user.email.downcase)
     end
-    if user
+    if Users::Authenticator.new(user).authenticate(@user.password)
       session[:user_id] = user.id
       redirect_to root_path
     else
@@ -29,7 +29,7 @@ class Users::SessionsController < ApplicationController
   private
 
     def user_params
-      params.require(:user).permit(:email, :password)
+      params.require(:users_login_form).permit(:email, :password)
     end
 
 end

--- a/app/forms/users/change_password_form.rb
+++ b/app/forms/users/change_password_form.rb
@@ -1,0 +1,22 @@
+class Users::ChangePasswordForm
+  include ActiveModel::Model
+
+  attr_accessor :object, :current_password, :new_password,
+                :new_password_confirmation
+
+  validates :new_password, presence: true, confirmation: true
+  
+  validate do
+    unless Users::Authenticator.new(object).authenticate(current_password)
+      errors.add(:current_password, :wrong)
+    end
+  end
+
+  def save
+    if valid?
+      object.password = new_password
+      object.save!
+    end
+  end
+
+end

--- a/app/forms/users/login_form.rb
+++ b/app/forms/users/login_form.rb
@@ -1,0 +1,5 @@
+class Users::LoginForm
+  include ActiveModel::Model
+
+  attr_accessor :email, :password
+end

--- a/app/services/users/authenticator.rb
+++ b/app/services/users/authenticator.rb
@@ -1,0 +1,11 @@
+class Users::Authenticator
+  def initialize(user)
+    @user = user
+  end
+
+  def authenticate(raw_password)
+    @user && 
+      @user.hashed_password && 
+        BCrypt::Password.new(@user.hashed_password) == raw_password
+  end
+end

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -15,12 +15,15 @@
       -# %ul.nav__lists-left
       -#   %li.list-lefts__item.lists-left__item--first
       %ul.nav__lists-right
-        %li.lists-right__item.lists-right__item--logout
-          ログアウト
-        = link_to post_app_apps_path do
+        - if current_user
+          %li.lists-right__item.lists-right__item--logout
+            = link_to "ログアウト", users_session_path, local: true, method: :delete
           %li.lists-right__item.lists-right__item--show
-            アプリ投稿
-        %li.lists-right__item.lists-right__item--login
-          ログイン
-        %li.lists-right__item.lists-right__item--new
-          新規会員登録
+            = link_to "アプリ投稿", new_app_post_path, local: true
+          %li.lists-right__item.lists-right__item--account
+            = link_to "アカウント管理画面", users_account_path, local: true
+        - else
+          %li.lists-right__item.lists-right__item--login
+            = link_to "ログイン", users_login_path, local: true
+          %li.lists-right__item.lists-right__item--new
+            = link_to "新規登録", users_sign_up_path, local: true

--- a/app/views/users/accounts/_form.html.haml
+++ b/app/views/users/accounts/_form.html.haml
@@ -18,6 +18,9 @@
     %div
       = f.label :password_confirmation, "確認用パスワード:" 
       = f.password_field :password_confirmation
-  %div
-    = f.submit "ログイン"
-    = link_to "topページ", root_path
+    %div
+      = f.submit "作成"
+  - elsif controller.action_name == "edit"
+    %div
+      = f.submit "編集"
+  = link_to "topページ", root_path

--- a/app/views/users/accounts/show.html.haml
+++ b/app/views/users/accounts/show.html.haml
@@ -1,0 +1,23 @@
+%h1 アカウント管理画面
+- if current_user
+  %div 
+    = link_to "アカウント編集", edit_users_account_path, local: true
+    = link_to "パスワード変更", edit_users_password_path, local: true
+  %table
+    %tr 
+      %td アカウント名
+      %td 
+        = @account.name
+    %tr 
+      %td メールアドレス
+      %td
+        = @account.email
+    %tr 
+      %td 生年月日
+      %td
+        = @account.birth_date
+    %tr 
+      %td パスワード
+      %td.password 
+        *********
+= link_to "topページ", root_path

--- a/app/views/users/passwords/edit.html.haml
+++ b/app/views/users/passwords/edit.html.haml
@@ -1,0 +1,15 @@
+%h1 パスワード変更
+%div
+  = form_with model: @change_password_form, url: :users_password, method: :patch, local: true do |f|
+    %div
+      = f.label :current_password, "現在のパスワード"
+      = f.password_field :current_password, size: 32, required: true
+    %div
+      = f.label :new_password, "新しいパスワード"
+      = f.password_field :new_password, size: 32, required: true
+    %div
+      = f.label :new_password_confirmation, "新しいパスワード(確認用)"
+      = f.password_field :new_password_confirmation, size: 32, required: true
+    %div
+      = f.submit "変更"
+      = link_to "キャンセル", users_account_path

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -10,3 +10,4 @@
       = f.password_field :password
     %div
       = f.submit "ログイン"
+= link_to "topページ", root_path

--- a/spec/requests/users/passwords_request_spec.rb
+++ b/spec/requests/users/passwords_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Users::Passwords", type: :request do
+
+end


### PR DESCRIPTION
# What
- ユーザーのパスワード変更機能の実装
  - ユーザー登録・編集時のためのフォームオブジェクトの作成
  - ユーザー認証機能実装のためのサービスオブジェクトの作成

- view/layout/_header.html.hamlの修正

# Why
- ユーザー登録・編集時のためのフォームオブジェクトの作成
  - ユーザ情報の登録、ログイン時、パスワード変更時のparamsの処理を切り分けるため
- ユーザー認証機能実装のためのサービスオブジェクトの作成
  - パスワードの認証のためのauthenticateメソッド作成、その認証機能をsession.controllerとpassword.controllerで本人確認のために使用するため
- view/layout/_header.html.hamlの修正
  - リンク先の修正により動作確認を行うため。